### PR TITLE
fix: username comparison

### DIFF
--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -66,16 +66,8 @@ export async function forceCloseMissingIssues(devpoolIssues: GitHubIssue[], proj
  * Stops forks from spamming real Ubiquity issues with links to their forks
  * @returns true if the authenticated user is Ubiquity
  */
-export async function checkIfForked() {
-  try {
-    const {
-      data: { id },
-    } = await octokit.users.getAuthenticated();
-    return id !== 76412717;
-  } catch (e: unknown) {
-    console.warn(`Getting authenticated user failed: ${e}`);
-    return false;
-  }
+export async function checkIfForked(user: string) {
+  return user !== "ubiquity";
 }
 
 /**


### PR DESCRIPTION
QA:
- The dev-pool posting: https://www.github.com/Keyrxng/devpool-directory/issues/20
- The linked dev-pool issue: https://www.github.com/ubiquity/pay.ubq.fi/issues/118
- The action: https://github.com/Keyrxng/devpool-directory/actions/runs/7964441365

This way despite the comment in the readme about not enabling actions, a forked repo will not link back to real UBQ issues if testing via the workflow

No longer using octokit but instead just a username comparison