### PR TITLE
PR: More Robust Server Error Handling

### DIFF
--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -99,6 +99,7 @@ export async function getRepoUrls(orgOrRepo: string) {
         repos = res.map((repo) => repo.html_url);
       } catch (e: unknown) {
         console.warn(`Getting ${orgOrRepo} org repositories failed: ${e}`);
+        throw e;
       }
       break;
     case 2: // owner/repo
@@ -112,6 +113,7 @@ export async function getRepoUrls(orgOrRepo: string) {
         } else console.warn(`Getting repo ${params[0]}/${params[1]} failed: ${res.status}`);
       } catch (e: unknown) {
         console.warn(`Getting repo ${params[0]}/${params[1]} failed: ${e}`);
+        throw e;
       }
       break;
     default:
@@ -357,5 +359,6 @@ export async function writeTotalRewardsToGithub(statistics: Statistics) {
     console.log(`Total rewards written to ${filePath}`);
   } catch (error) {
     console.error(`Error writing total rewards to github file: ${error}`);
+    throw error;
   }
 }

--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -97,9 +97,9 @@ export async function getRepoUrls(orgOrRepo: string) {
           org: orgOrRepo,
         });
         repos = res.map((repo) => repo.html_url);
-      } catch (e: unknown) {
-        console.warn(`Getting ${orgOrRepo} org repositories failed: ${e}`);
-        throw e;
+      } catch (error: unknown) {
+        console.warn(`Getting ${orgOrRepo} org repositories failed: ${error}`);
+        throw error;
       }
       break;
     case 2: // owner/repo
@@ -111,9 +111,9 @@ export async function getRepoUrls(orgOrRepo: string) {
         if (res.status === 200) {
           repos.push(res.data.html_url);
         } else console.warn(`Getting repo ${params[0]}/${params[1]} failed: ${res.status}`);
-      } catch (e: unknown) {
-        console.warn(`Getting repo ${params[0]}/${params[1]} failed: ${e}`);
-        throw e;
+      } catch (error: unknown) {
+        console.warn(`Getting repo ${params[0]}/${params[1]} failed: ${error}`);
+        throw error;
       }
       break;
     default:

--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,9 @@ async function main() {
       for (const projectIssue of projectIssues) {
         // if issue exists in devpool
         const devpoolIssue = getIssueByLabel(devpoolIssues, `id: ${projectIssue.node_id}`);
+
+        // adding wwww creates a link to an issue that does not count as a mention
+        // helps with preventing a mention in partner's repo especially during testing
         const body = isFork ? projectIssue.html_url.replace("https://github.com", "https://www.github.com") : projectIssue.html_url;
 
         if (devpoolIssue) {

--- a/index.ts
+++ b/index.ts
@@ -37,168 +37,160 @@ async function main() {
     await writeFile("./twitterMap.json", JSON.stringify({}));
   }
 
-  try {
-    // get devpool issues
-    const devpoolIssues: GitHubIssue[] = await getAllIssues(DEVPOOL_OWNER_NAME, DEVPOOL_REPO_NAME);
+  // get devpool issues
+  const devpoolIssues: GitHubIssue[] = await getAllIssues(DEVPOOL_OWNER_NAME, DEVPOOL_REPO_NAME);
 
-    // Calculate total rewards from open issues
-    const { rewards, tasks } = await calculateStatistics(devpoolIssues);
-    const statistics: Statistics = { rewards, tasks };
+  // Calculate total rewards from open issues
+  const { rewards, tasks } = await calculateStatistics(devpoolIssues);
+  const statistics: Statistics = { rewards, tasks };
 
-    await writeTotalRewardsToGithub(statistics);
+  await writeTotalRewardsToGithub(statistics);
 
-    // aggregate projects.urls and opt settings
-    const projectUrls = await getProjectUrls();
+  // aggregate projects.urls and opt settings
+  const projectUrls = await getProjectUrls();
 
+  // aggregate all project issues
+  const allProjectIssues: GitHubIssue[] = [];
+
+  const isFork = await checkIfForked(DEVPOOL_OWNER_NAME);
+
+  // for each project URL
+  for (const projectUrl of projectUrls) {
+    // get owner and repository names from project URL
+    const [ownerName, repoName] = getRepoCredentials(projectUrl);
+    // get all project issues (opened and closed)
+    const projectIssues: GitHubIssue[] = await getAllIssues(ownerName, repoName);
     // aggregate all project issues
-    const allProjectIssues: GitHubIssue[] = [];
+    allProjectIssues.push(...projectIssues);
+    // for all issues
+    for (const projectIssue of projectIssues) {
+      // if issue exists in devpool
+      const devpoolIssue = getIssueByLabel(devpoolIssues, `id: ${projectIssue.node_id}`);
 
-    const isFork = await checkIfForked(DEVPOOL_OWNER_NAME);
+      // adding wwww creates a link to an issue that does not count as a mention
+      // helps with preventing a mention in partner's repo especially during testing
+      const body = isFork ? projectIssue.html_url.replace("https://github.com", "https://www.github.com") : projectIssue.html_url;
 
-    // for each project URL
-    for (const projectUrl of projectUrls) {
-      // get owner and repository names from project URL
-      const [ownerName, repoName] = getRepoCredentials(projectUrl);
-      // get all project issues (opened and closed)
-      const projectIssues: GitHubIssue[] = await getAllIssues(ownerName, repoName);
-      // aggregate all project issues
-      allProjectIssues.push(...projectIssues);
-      // for all issues
-      for (const projectIssue of projectIssues) {
-        // if issue exists in devpool
-        const devpoolIssue = getIssueByLabel(devpoolIssues, `id: ${projectIssue.node_id}`);
-
-        // adding wwww creates a link to an issue that does not count as a mention
-        // helps with preventing a mention in partner's repo especially during testing
-        const body = isFork ? projectIssue.html_url.replace("https://github.com", "https://www.github.com") : projectIssue.html_url;
-
-        if (devpoolIssue) {
-          if (projectIssue.state == "closed") {
-            if (twitterMap[devpoolIssue.node_id]) {
-              await twitter.deleteTweet(twitterMap[devpoolIssue.node_id]);
-              delete twitterMap[devpoolIssue.node_id];
-              await writeFile("./twitterMap.json", JSON.stringify(twitterMap));
-            }
+      if (devpoolIssue) {
+        if (projectIssue.state == "closed") {
+          if (twitterMap[devpoolIssue.node_id]) {
+            await twitter.deleteTweet(twitterMap[devpoolIssue.node_id]);
+            delete twitterMap[devpoolIssue.node_id];
+            await writeFile("./twitterMap.json", JSON.stringify(twitterMap));
           }
+        }
 
-          // If project issue doesn't have the "Price" label (i.e. it has been removed) then close
-          // the devpool issue if it is not already closed, no need to pollute devpool repo with draft issues
-          if (!(projectIssue.labels as GitHubLabel[]).some((label) => label.name.includes(LABELS.PRICE))) {
-            if (devpoolIssue.state === "open") {
-              await octokit.rest.issues.update({
-                owner: DEVPOOL_OWNER_NAME,
-                repo: DEVPOOL_REPO_NAME,
-                issue_number: devpoolIssue.number,
-                state: "closed",
-              });
-              console.log(`Closed (price label not set): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
-            } else {
-              console.log(`Already closed (price label not set): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
-            }
-            continue;
-          }
-
-          // if the project issue is assigned to someone and it's open in the devpool, then close it
-          if (projectIssue.assignee?.login && devpoolIssue.state === "open") {
+        // If project issue doesn't have the "Price" label (i.e. it has been removed) then close
+        // the devpool issue if it is not already closed, no need to pollute devpool repo with draft issues
+        if (!(projectIssue.labels as GitHubLabel[]).some((label) => label.name.includes(LABELS.PRICE))) {
+          if (devpoolIssue.state === "open") {
             await octokit.rest.issues.update({
               owner: DEVPOOL_OWNER_NAME,
               repo: DEVPOOL_REPO_NAME,
               issue_number: devpoolIssue.number,
               state: "closed",
             });
-            console.log(`Closed (assigned): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
-            continue;
-          }
-
-          // if the project issue is not assigned to someone and it's closed in the devpool, then reopen it
-          if (!projectIssue.assignee?.login && projectIssue.state === "open" && devpoolIssue.state === "closed") {
-            await octokit.rest.issues.update({
-              owner: DEVPOOL_OWNER_NAME,
-              repo: DEVPOOL_REPO_NAME,
-              issue_number: devpoolIssue.number,
-              state: "open",
-            });
-            console.log(`Reopened (unassigned): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
-            continue;
-          }
-
-          // prepare for issue updating
-          const isDevpoolUnavailableLabel = (devpoolIssue.labels as GitHubLabel[])?.some((label) => label.name === LABELS.UNAVAILABLE);
-          const devpoolIssueLabelsStringified = (devpoolIssue.labels as GitHubLabel[])
-            .map((label) => label.name)
-            .sort()
-            .toString();
-          const projectIssueLabelsStringified = getDevpoolIssueLabels(projectIssue, projectUrl).sort().toString();
-
-          // Update devpool issue if any of the following has been updated:
-          // - issue title
-          // - issue state (open/closed)
-          // - assignee (exists or not)
-          // - repository name (devpool issue body contains a partner project issue URL)
-          // - any label
-          if (
-            devpoolIssue.title !== projectIssue.title ||
-            devpoolIssue.state !== projectIssue.state ||
-            (!isDevpoolUnavailableLabel && projectIssue.assignee?.login) ||
-            (isDevpoolUnavailableLabel && !projectIssue.assignee?.login) ||
-            devpoolIssue.body !== projectIssue.html_url ||
-            devpoolIssueLabelsStringified !== projectIssueLabelsStringified
-          ) {
-            await octokit.rest.issues.update({
-              owner: DEVPOOL_OWNER_NAME,
-              repo: DEVPOOL_REPO_NAME,
-              issue_number: devpoolIssue.number,
-              title: projectIssue.title,
-              body,
-              state: projectIssue.state as "open" | "closed",
-              labels: getDevpoolIssueLabels(projectIssue, projectUrl),
-            });
-            console.log(`Updated: ${devpoolIssue.html_url} (${projectIssue.html_url})`);
+            console.log(`Closed (price label not set): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
           } else {
-            console.log(`No updates: ${devpoolIssue.html_url} (${projectIssue.html_url})`);
+            console.log(`Already closed (price label not set): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
           }
-        } else {
-          // issue does not exist in devpool
-          // if issue is "closed" then skip it, no need to copy/paste already "closed" issues
-          if (projectIssue.state === "closed") continue;
-          // if issue doesn't have the "Price" label then skip it, no need to pollute repo with draft issues
-          if (!(projectIssue.labels as GitHubLabel[]).some((label) => label.name.includes(LABELS.PRICE))) continue;
-          // if the project issue is assigned to someone, then skip it
-          if (projectIssue.assignee?.login) continue;
+          continue;
+        }
 
-          // create a new issue
-          const createdIssue = await octokit.rest.issues.create({
+        // if the project issue is assigned to someone and it's open in the devpool, then close it
+        if (projectIssue.assignee?.login && devpoolIssue.state === "open") {
+          await octokit.rest.issues.update({
             owner: DEVPOOL_OWNER_NAME,
             repo: DEVPOOL_REPO_NAME,
+            issue_number: devpoolIssue.number,
+            state: "closed",
+          });
+          console.log(`Closed (assigned): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
+          continue;
+        }
+
+        // if the project issue is not assigned to someone and it's closed in the devpool, then reopen it
+        if (!projectIssue.assignee?.login && projectIssue.state === "open" && devpoolIssue.state === "closed") {
+          await octokit.rest.issues.update({
+            owner: DEVPOOL_OWNER_NAME,
+            repo: DEVPOOL_REPO_NAME,
+            issue_number: devpoolIssue.number,
+            state: "open",
+          });
+          console.log(`Reopened (unassigned): ${devpoolIssue.html_url} (${projectIssue.html_url})`);
+          continue;
+        }
+
+        // prepare for issue updating
+        const isDevpoolUnavailableLabel = (devpoolIssue.labels as GitHubLabel[])?.some((label) => label.name === LABELS.UNAVAILABLE);
+        const devpoolIssueLabelsStringified = (devpoolIssue.labels as GitHubLabel[])
+          .map((label) => label.name)
+          .sort()
+          .toString();
+        const projectIssueLabelsStringified = getDevpoolIssueLabels(projectIssue, projectUrl).sort().toString();
+
+        // Update devpool issue if any of the following has been updated:
+        // - issue title
+        // - issue state (open/closed)
+        // - assignee (exists or not)
+        // - repository name (devpool issue body contains a partner project issue URL)
+        // - any label
+        if (
+          devpoolIssue.title !== projectIssue.title ||
+          devpoolIssue.state !== projectIssue.state ||
+          (!isDevpoolUnavailableLabel && projectIssue.assignee?.login) ||
+          (isDevpoolUnavailableLabel && !projectIssue.assignee?.login) ||
+          devpoolIssue.body !== projectIssue.html_url ||
+          devpoolIssueLabelsStringified !== projectIssueLabelsStringified
+        ) {
+          await octokit.rest.issues.update({
+            owner: DEVPOOL_OWNER_NAME,
+            repo: DEVPOOL_REPO_NAME,
+            issue_number: devpoolIssue.number,
             title: projectIssue.title,
             body,
+            state: projectIssue.state as "open" | "closed",
             labels: getDevpoolIssueLabels(projectIssue, projectUrl),
           });
-          console.log(`Created: ${createdIssue.data.html_url} (${projectIssue.html_url})`);
-
-          // post to social media
-          const socialMediaText = getSocialMediaText(createdIssue.data);
-          const tweetId = await twitter.postTweet(socialMediaText);
-
-          twitterMap[createdIssue.data.node_id] = tweetId?.id ?? "";
-          await writeFile("./twitterMap.json", JSON.stringify(twitterMap));
+          console.log(`Updated: ${devpoolIssue.html_url} (${projectIssue.html_url})`);
+        } else {
+          console.log(`No updates: ${devpoolIssue.html_url} (${projectIssue.html_url})`);
         }
+      } else {
+        // issue does not exist in devpool
+        // if issue is "closed" then skip it, no need to copy/paste already "closed" issues
+        if (projectIssue.state === "closed") continue;
+        // if issue doesn't have the "Price" label then skip it, no need to pollute repo with draft issues
+        if (!(projectIssue.labels as GitHubLabel[]).some((label) => label.name.includes(LABELS.PRICE))) continue;
+        // if the project issue is assigned to someone, then skip it
+        if (projectIssue.assignee?.login) continue;
+
+        // create a new issue
+        const createdIssue = await octokit.rest.issues.create({
+          owner: DEVPOOL_OWNER_NAME,
+          repo: DEVPOOL_REPO_NAME,
+          title: projectIssue.title,
+          body,
+          labels: getDevpoolIssueLabels(projectIssue, projectUrl),
+        });
+        console.log(`Created: ${createdIssue.data.html_url} (${projectIssue.html_url})`);
+
+        // post to social media
+        const socialMediaText = getSocialMediaText(createdIssue.data);
+        const tweetId = await twitter.postTweet(socialMediaText);
+
+        twitterMap[createdIssue.data.node_id] = tweetId?.id ?? "";
+        await writeFile("./twitterMap.json", JSON.stringify(twitterMap));
       }
     }
-
-    // close missing issues
-    await forceCloseMissingIssues(devpoolIssues, allProjectIssues);
-  } catch (err) {
-    console.error(err);
   }
+
+  // close missing issues
+  await forceCloseMissingIssues(devpoolIssues, allProjectIssues);
 }
 
 void (async () => {
-  try {
-    await main();
-  } catch (error) {
-    console.error(error);
-  }
+  await main();
 })();
 
 // Expose the main only for testing purposes

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -16,8 +16,6 @@ describe("Devpool Updates", () => {
   beforeAll(async () => {
     // @ts-expect-error main() is only exported for testing
     main = await (await import("../index")).main;
-    // silence stderr since we expect errors to be logged
-    jest.spyOn(console, "warn").mockImplementation(jest.fn());
   });
 
   beforeEach(() => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -22,18 +22,20 @@ describe("Devpool Updates", () => {
     drop(db);
 
     // Add all the default repos of the organization
-    for (let i = 0; i < opt.out.length; ++i) {
-      const repoName = opt.out[i].split("/")[1];
-      db.repo.create({
-        id: i + 1,
-        owner: DEVPOOL_OWNER_NAME,
-        name: repoName,
-        html_url: `https://github.com/${DEVPOOL_OWNER_NAME}/${repoName}`,
-      });
+    const repos = opt.in.concat(opt.out);
+    for (let i = 0; i < repos.length; ++i) {
+      const repoFromOpt = repos[i].split("/");
+      if (repoFromOpt.length == 2) {
+        db.repo.create({
+          id: i + 1,
+          owner: repoFromOpt[0],
+          name: repoFromOpt[1],
+          html_url: `https://github.com/${repoFromOpt[0]}/${repoFromOpt[1]}`,
+        });
+      }
     }
-
     db.repo.create({
-      id: opt.out.length + 1,
+      id: repos.length + 1,
       owner: DEVPOOL_OWNER_NAME,
       name: "test-repo",
       html_url: `https://github.com/${DEVPOOL_OWNER_NAME}/test-repo`,


### PR DESCRIPTION
Resolves https://github.com/ubiquity/devpool-directory-bounties/issues/21

It turned out try/catch isn't always a good idea. When the "Sync Issues" action failed, it was showing the action passed, with green tick. 
https://github.com/ubiquity/devpool-directory/actions/runs/8259431257/job/22593325855#step:7:12

Letting the error propagate was the solution. No try/catch in main function. Let it return to the action as a failure. Also, when the most important parts of the code throw an error, the error propagates and no more steps are performed in the code, where closing the issues is the last step. 

Here is a QA for failure. What happens if there is 404, timeout, rate limit, or other errors? Sync issue fails, shows clear failure in Github actions, and the error log shows complete details. Even though this is a 404 error, you can also see rate limit details in the error logs that come with all requests. 
https://github.com/EresDevOrg/devpool-directory-qa/actions/runs/8361911852/job/22891165425#step:7:18

QA with success: https://github.com/EresDevOrg/devpool-directory-qa/actions/runs/8362787261/job/22894236651

Attention must be given to merge. A merge to production can reveal other problems that were previously hidden due to the false positive nature of the Sync Issues action. 

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
