### PR TITLE
fix: close assigned issue logic

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -149,7 +149,7 @@ async function main() {
             issue_number: devpoolIssue.number,
             title: projectIssue.title,
             body,
-            state: projectIssue.state as "open" | "closed",
+            state: !isDevpoolUnavailableLabel ? (projectIssue.state as "open" | "closed") : "closed",
             labels: getDevpoolIssueLabels(projectIssue, projectUrl),
           });
           console.log(`Updated: ${devpoolIssue.html_url} (${projectIssue.html_url})`);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -106,4 +106,30 @@ describe("Devpool Updates", () => {
       },
     ]);
   });
+
+  test("Close devpool issues when the issue has been assigned in other projects", async () => {
+    db.issue.create({
+      ...issueDevpoolTemplate,
+      id: 1,
+      owner: DEVPOOL_OWNER_NAME,
+      repo: DEVPOOL_REPO_NAME,
+    });
+    db.issue.create({
+      ...issueTemplate,
+      id: 2,
+      assignee: { ...issueTemplate.assignee, login: "john doe" },
+      owner: DEVPOOL_OWNER_NAME,
+      repo: "test-repo",
+    });
+    await main();
+    const devpoolIssue = await getAllIssues(DEVPOOL_OWNER_NAME, DEVPOOL_REPO_NAME);
+
+    expect(devpoolIssue).toMatchObject([
+      {
+        ...issueDevpoolTemplate,
+        id: 1,
+        state: "closed",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
### closes: [#23](https://github.com/ubiquity/devpool-directory-bounties/issues/23)

### Solution

I realized that the existing logic for closing assigned issues works correctly, but the logic for updating issue always reopens the issue again

```js 
        if (
          devpoolIssue.title !== projectIssue.title ||
          devpoolIssue.state !== projectIssue.state || // <-- since the states are different, if block runs
          (!isDevpoolUnavailableLabel && projectIssue.assignee?.login) ||
          (isDevpoolUnavailableLabel && !projectIssue.assignee?.login) ||
          devpoolIssue.body !== projectIssue.html_url ||
          devpoolIssueLabelsStringified !== projectIssueLabelsStringified
        ) {
          await octokit.rest.issues.update({
            owner: DEVPOOL_OWNER_NAME,
            repo: DEVPOOL_REPO_NAME,
            issue_number: devpoolIssue.number,
            title: projectIssue.title,
            body,
            state: projectIssue.state as "open" | "closed", // <--- projectIssue state is set back to "open"
            labels: getDevpoolIssueLabels(projectIssue, projectUrl),
          });
          console.log(`Updated: ${devpoolIssue.html_url} (${projectIssue.html_url})`);
        } else {
          console.log(`No updates: ${devpoolIssue.html_url} (${projectIssue.html_url})`);
        }
``` 

You can see this behaviour on this [issue](https://github.com/ubiquity/devpool-directory/issues/1154) or on the screenshot below

![evidence](https://github.com/ubiquity/devpool-directory/assets/117433403/b6e32f0c-b215-4908-8b97-22a9f8a89f29)

### Change 

- [x] refactored the logic that updates issue 

```js 
// reopen issue only if it doesn't have the `Unavaliable` label 
state: !isDevpoolUnavailableLabel ? (projectIssue.state as "open" | "closed") : "closed",
``` 

- [x] added tests to assert that current functionality (closing of assigned issues) works properly and test are passing locally

![work ubi test](https://github.com/ubiquity/devpool-directory/assets/117433403/d6499ad3-bf66-42c4-89cc-ec1b7b3161a3)
