### PR TITLE
fix: ignore unauthorized issue creation and add authorized users array

### DIFF
--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -23,7 +23,11 @@ export const projects = _projects as {
   category?: Record<string, string>;
 };
 
-const authorizedOrgIds = ["76412717", "133917611", "165700353"];
+const authorizedOrgs = {
+  "ubiquity": 76412717,
+  "ubiquibot": 133917611,
+  "UbiquityOS": 165700353,
+};
 export const DEVPOOL_OWNER_NAME = "ubiquity";
 export const DEVPOOL_REPO_NAME = "devpool-directory";
 export enum LABELS {
@@ -401,8 +405,8 @@ export async function createDevPoolIssue(projectIssue: GitHubIssue, projectUrl: 
     });
 
      // Check if the user belongs to any authorized organizations
-     const isAuthorized = userOrgs.data.some((org) =>
-      authorizedOrgIds.includes(org.id.toString())
+    const isAuthorized = userOrgs.data.some((org) =>
+      Object.values(authorizedOrgs).includes(org.id)
     );
 
     if (!isAuthorized) {

--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -22,7 +22,7 @@ export const projects = _projects as {
   urls: string[];
   category?: Record<string, string>;
 };
-
+const authorizedUsers = ["ubiquibot", "ubiquityos"];
 export const DEVPOOL_OWNER_NAME = "ubiquity";
 export const DEVPOOL_REPO_NAME = "devpool-directory";
 export enum LABELS {
@@ -382,6 +382,9 @@ export async function createDevPoolIssue(projectIssue: GitHubIssue, projectUrl: 
 
   // if issue doesn't have the "Price" label then skip it, no need to pollute repo with draft issues
   if (!(projectIssue.labels as GitHubLabel[]).some((label) => label.name.includes(LABELS.PRICE))) return;
+
+  // if the issue is opened by someone other than "ubiquibot" or "UbiquityOS", skip it
+  if (!authorizedUsers.includes(projectIssue.user?.login as string)) return;
 
   // create a new issue
   try {

--- a/tests/devpool-issue-handler.test.ts
+++ b/tests/devpool-issue-handler.test.ts
@@ -1428,39 +1428,6 @@ describe("createDevPoolIssue", () => {
       expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("Created"));
     });
 
-    test("does not create a new devpool issue if it isnt created by ubiquibot", async () => {
-      const unauthorizedBot = {
-        login: "unauthorizedBot",
-      } as GitHubIssue["user"];
-
-      const partnerIssue = {
-        ...issueTemplate,
-        user: unauthorizedBot,
-      } as GitHubIssue;
-
-      db.issue.create({
-        ...issueDevpoolTemplate,
-        title: partnerIssue.title,
-        body: partnerIssue.html_url,
-        repository_url: UBIQUITY_TEST_REPO,
-      });
-
-      await createDevPoolIssue(partnerIssue, partnerIssue.html_url, UBIQUITY_TEST_REPO, twitterMap);
-
-      // Verify that no new issue was created
-      const devpoolIssue = db.issue.findFirst({
-        where: {
-          title: {
-            equals: partnerIssue.title,
-          },
-        },
-      }) as GitHubIssue;
-
-      expect(devpoolIssue).not.toBeNull();
-
-      expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("Created"));
-    });
-
     test("does not create a new devpool issue if it's assigned", async () => {
       const partnerIssue = {
         ...issueTemplate,

--- a/tests/devpool-issue-handler.test.ts
+++ b/tests/devpool-issue-handler.test.ts
@@ -1428,6 +1428,39 @@ describe("createDevPoolIssue", () => {
       expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("Created"));
     });
 
+    test("does not create a new devpool issue if it isnt created by ubiquibot", async () => {
+      const unauthorizedBot = {
+        login: "unauthorizedBot",
+      } as GitHubIssue["user"];
+
+      const partnerIssue = {
+        ...issueTemplate,
+        user: unauthorizedBot,
+      } as GitHubIssue;
+
+      db.issue.create({
+        ...issueDevpoolTemplate,
+        title: partnerIssue.title,
+        body: partnerIssue.html_url,
+        repository_url: UBIQUITY_TEST_REPO,
+      });
+
+      await createDevPoolIssue(partnerIssue, partnerIssue.html_url, UBIQUITY_TEST_REPO, twitterMap);
+
+      // Verify that no new issue was created
+      const devpoolIssue = db.issue.findFirst({
+        where: {
+          title: {
+            equals: partnerIssue.title,
+          },
+        },
+      }) as GitHubIssue;
+
+      expect(devpoolIssue).not.toBeNull();
+
+      expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("Created"));
+    });
+
     test("does not create a new devpool issue if it's assigned", async () => {
       const partnerIssue = {
         ...issueTemplate,


### PR DESCRIPTION
Resolve: [#30](https://github.com/ubiquity/devpool-directory-bounties/issues/30)

This PR introduces a fix to ignore issues opened by unauthorized users. An array of authorized users has been added, allowing easy management of users who can open issues. The function now skips processing issues created by users not included in this array.

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
