### PR TITLE
refactor body ternary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ total-rewards.txt
 total-rewards.json
 junit.xml
 statistics.json
+test-script.ts

--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -23,7 +23,7 @@ export const projects = _projects as {
   category?: Record<string, string>;
 };
 
-export const DEVPOOL_OWNER_NAME = "ubiquity";
+export const DEVPOOL_OWNER_NAME = "ubq-testing";
 export const DEVPOOL_REPO_NAME = "devpool-directory";
 export enum LABELS {
   PRICE = "Price",

--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -462,13 +462,21 @@ async function applyMetaChanges(
   const shouldUpdate = metaChanges.title || metaChanges.body || metaChanges.labels;
 
   if (shouldUpdate) {
+    let newBody = devpoolIssue.body;
+
+    if (metaChanges.body && !isFork) {
+      newBody = projectIssue.html_url;
+    } else {
+      newBody = projectIssue.html_url.replace("https://", "https://www.");
+    }
+
     try {
       await octokit.rest.issues.update({
         owner: DEVPOOL_OWNER_NAME,
         repo: DEVPOOL_REPO_NAME,
         issue_number: devpoolIssue.number,
         title: metaChanges.title ? projectIssue.title : devpoolIssue.title,
-        body: metaChanges.body && !isFork ? projectIssue.html_url : projectIssue.html_url.replace("https://", "https://www."),
+        body: newBody,
         labels: metaChanges.labels ? labelRemoved : originals,
       });
     } catch (err) {

--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -23,7 +23,7 @@ export const projects = _projects as {
   category?: Record<string, string>;
 };
 
-export const DEVPOOL_OWNER_NAME = "ubq-testing";
+export const DEVPOOL_OWNER_NAME = "ubiquity";
 export const DEVPOOL_REPO_NAME = "devpool-directory";
 export enum LABELS {
   PRICE = "Price",

--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -428,11 +428,21 @@ export async function handleDevPoolIssue(
   const hasChanges = !areEqual(originals, labelRemoved);
   const hasNoPriceLabels = !(projectIssue.labels as GitHubLabel[]).some((label) => label.name.includes(LABELS.PRICE));
 
+  let shouldUpdateBody = false;
+
+  if (!isFork && devpoolIssue.body != projectIssue.html_url) {
+    // not a fork, so body uses https://github.com
+    shouldUpdateBody = true;
+  } else if (isFork && devpoolIssue.body != projectIssue.html_url.replace("https://", "https://www.")) {
+    // it's a fork, so body uses https://www.github.com
+    shouldUpdateBody = true;
+  }
+
   const metaChanges = {
     // the title of the issue has changed
     title: devpoolIssue.title != projectIssue.title,
     // the issue url has updated
-    body: !isFork && devpoolIssue.body != projectIssue.html_url,
+    body: shouldUpdateBody,
     // the price/priority labels have changed
     labels: hasChanges,
   };
@@ -483,9 +493,7 @@ async function applyMetaChanges(
       console.error(err);
     }
 
-    if (metaChanges.title || metaChanges.body || metaChanges.labels) {
-      console.log(`Updated metadata: ${devpoolIssue.html_url} (${projectIssue.html_url})`);
-    }
+    console.log(`Updated metadata: ${devpoolIssue.html_url} - (${projectIssue.html_url})`, metaChanges);
   }
 }
 

--- a/tests/devpool-issue-handler.test.ts
+++ b/tests/devpool-issue-handler.test.ts
@@ -103,7 +103,7 @@ describe("handleDevPoolIssue", () => {
       }) as GitHubIssue;
 
       expect(updatedIssue).not.toBeNull();
-      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} (${partnerIssue.html_url})`);
+      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} - (${partnerIssue.html_url})`, { body: false, "labels": true, title: true });
     });
 
     test("updates issue labels in devpool when project issue labels change", async () => {
@@ -132,7 +132,7 @@ describe("handleDevPoolIssue", () => {
       expect(updatedIssue).not.toBeNull();
       expect(updatedIssue?.labels).toEqual(expect.arrayContaining([{ name: "enhancement" }]));
 
-      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} (${partnerIssue.html_url})`);
+      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} - (${partnerIssue.html_url})`, { body: false, "labels": true, title: false });
     });
 
     test("does not update issue when no metadata changes are detected", async () => {
@@ -1018,7 +1018,7 @@ describe("handleDevPoolIssue", () => {
       expect(updatedIssue).not.toBeNull();
       expect(updatedIssue?.title).toEqual("Updated Title");
 
-      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} (${partnerIssue.html_url})`);
+      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} - (${partnerIssue.html_url})`, { body: false, "labels": true, title: true });
     });
 
     test("updates issue labels in devpool when project issue labels change in forked repo", async () => {
@@ -1049,7 +1049,7 @@ describe("handleDevPoolIssue", () => {
 
       expect(updatedIssue).not.toBeNull();
 
-      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} (${partnerIssue.html_url})`);
+      expect(logSpy).toHaveBeenCalledWith(`Updated metadata: ${updatedIssue.html_url} - (${partnerIssue.html_url})`, { body: false, "labels": true, title: false });
     });
 
     test("closes devpool issue when project issue is missing in forked repo", async () => {


### PR DESCRIPTION
Related to https://github.com/ubiquity/work.ubq.fi/pull/91

testing locally against production by running the main script without performing state changing actions I think this is the solution.

I say think because the prod devpool issue sits in one of two states: real url and fork url.

When I test it against the real url, it says no change and when it's forked it tells me to change. I cannot test in my own devpool effectively so I'm going to merge and test in prod.

I have improved the logs a little to get more info too.