### PR TITLE
refactor: replace syncIssueMetaData with updateDirectoryIssue and upd…

### DIFF
--- a/src/directory/get-issue-by-label.ts
+++ b/src/directory/get-issue-by-label.ts
@@ -2,14 +2,14 @@ import { GitHubIssue, GitHubLabel } from "./directory";
 
 /**
  * Returns issue by label
- * @param issues issues array
- * @param label label string
+ * @param searchIssues issues array
+ * @param searchLabel label string
  */
 
-export function getIssueByLabel(issues: GitHubIssue[], label: string) {
-  issues = issues.filter((issue) => {
-    const labels = (issue.labels as GitHubLabel[]).filter((obj) => obj.name === label);
+export function getIssueByLabel(searchIssues: GitHubIssue[], searchLabel: string) {
+  searchIssues = searchIssues.filter((issue) => {
+    const labels = (issue.labels as GitHubLabel[]).filter((obj) => obj.name === searchLabel);
     return labels.length > 0;
   });
-  return issues.length > 0 ? issues[0] : null;
+  return searchIssues.length > 0 ? searchIssues[0] : null;
 }

--- a/src/directory/set-meta-changes.ts
+++ b/src/directory/set-meta-changes.ts
@@ -1,8 +1,8 @@
 import { checkIfForked } from "./check-if-forked";
 import { DEVPOOL_OWNER_NAME, DEVPOOL_REPO_NAME, octokit } from "./directory";
-import { MetadataInterface } from "./sync-issue-meta-data";
+import { MetadataInterface } from "./update-issue";
 
-export async function setMetaChanges({ metaChanges, partnerIssue, directoryIssue, labelRemoved, originalLabels }: MetadataInterface) {
+export async function setMetaChanges({ issueDelta: metaChanges, partnerIssue, directoryIssue, labelRemoved, originalLabels }: MetadataInterface) {
   const shouldUpdate = metaChanges.title || metaChanges.body || metaChanges.labels;
 
   if (shouldUpdate) {
@@ -20,6 +20,7 @@ export async function setMetaChanges({ metaChanges, partnerIssue, directoryIssue
         title: directoryIssue.title,
         body: directoryIssueBody,
         labels: metaChanges.labels ? labelRemoved : originalLabels,
+        state: partnerIssue.state === "closed" ? "closed" : "open",
       });
     } catch (err) {
       console.error(err);

--- a/src/directory/set-unavailable-label-to-issue.ts
+++ b/src/directory/set-unavailable-label-to-issue.ts
@@ -1,7 +1,7 @@
 import { DEVPOOL_OWNER_NAME, DEVPOOL_REPO_NAME, GitHubLabel, Labels, octokit } from "./directory";
-import { MetadataInterface } from "./sync-issue-meta-data";
+import { MetadataInterface } from "./update-issue";
 
-export async function setUnavailableLabelToIssue({ directoryIssue, partnerIssue, metaChanges, labelRemoved, originalLabels }: MetadataInterface) {
+export async function setUnavailableLabelToIssue({ directoryIssue, partnerIssue, issueDelta, labelRemoved, originalLabels }: MetadataInterface) {
   const hasUnavailableLabel = directoryIssue.labels.some((label) => (label as GitHubLabel).name === Labels.UNAVAILABLE);
   const isProjectAssigned = !!partnerIssue.assignees?.length;
   const isProjectOpen = partnerIssue.state === "open";
@@ -20,7 +20,7 @@ export async function setUnavailableLabelToIssue({ directoryIssue, partnerIssue,
         owner: DEVPOOL_OWNER_NAME,
         repo: DEVPOOL_REPO_NAME,
         issue_number: directoryIssue.number,
-        labels: metaChanges.labels ? labelRemoved.concat(Labels.UNAVAILABLE) : originalLabels.concat(Labels.UNAVAILABLE),
+        labels: issueDelta.labels ? labelRemoved.concat(Labels.UNAVAILABLE) : originalLabels.concat(Labels.UNAVAILABLE),
       });
       console.log(`Added label "${Labels.UNAVAILABLE}" to Issue #${directoryIssue.number}`);
     } catch (err) {

--- a/src/directory/sync-partner-repo-issues.ts
+++ b/src/directory/sync-partner-repo-issues.ts
@@ -4,7 +4,7 @@ import { getIssueByLabel } from "./get-issue-by-label";
 import { getRepoCredentials } from "./get-repo-credentials";
 import { getRepositoryIssues } from "./get-repository-issues";
 import { newDirectoryIssue } from "./new-directory-issue";
-import { syncIssueMetaData as syncDirectoryIssue } from "./sync-issue-meta-data";
+import { updateDirectoryIssue } from "./update-issue";
 
 export async function syncPartnerRepoIssues({
   partnerRepoUrl,
@@ -36,7 +36,7 @@ export async function syncPartnerRepoIssues({
 
     if (directoryIssue) {
       // if it exists in the Directory, then update it
-      await syncDirectoryIssue({
+      await updateDirectoryIssue({
         partnerIssue: partnerIssue,
         directoryIssue: directoryIssue,
       });

--- a/src/directory/update-issue.ts
+++ b/src/directory/update-issue.ts
@@ -4,7 +4,7 @@ import { getDirectoryIssueLabelsFromPartnerIssue } from "./get-directory-issue-l
 import { setMetaChanges } from "./set-meta-changes";
 import { setUnavailableLabelToIssue } from "./set-unavailable-label-to-issue";
 
-export async function syncIssueMetaData({ directoryIssue, partnerIssue }: { directoryIssue: GitHubIssue; partnerIssue: GitHubIssue }) {
+export async function updateDirectoryIssue({ directoryIssue, partnerIssue }: { directoryIssue: GitHubIssue; partnerIssue: GitHubIssue }) {
   // remove the "unavailable" label as this adds it and statistics rely on it
   const labelRemoved = getDirectoryIssueLabelsFromPartnerIssue(partnerIssue).filter((label) => label != Labels.UNAVAILABLE);
   const originalLabels = partnerIssue.labels.map((label) => (label as GitHubLabel).name);
@@ -15,14 +15,14 @@ export async function syncIssueMetaData({ directoryIssue, partnerIssue }: { dire
     partnerIssueUrl = partnerIssue.html_url.replace("https://github.com", "https://www.github.com");
   }
 
-  const metaChanges: MetaChanges = {
+  const issueDelta: IssueDelta = {
     title: directoryIssue.title !== partnerIssue.title,
     body: directoryIssue.body !== partnerIssueUrl,
     labels: !areEqual(originalLabels, labelRemoved),
   };
 
   const metadata: MetadataInterface = {
-    metaChanges,
+    issueDelta,
     partnerIssue,
     directoryIssue,
     labelRemoved,
@@ -37,14 +37,14 @@ function areEqual(a: string[], b: string[]) {
 }
 
 export interface MetadataInterface {
-  metaChanges: MetaChanges;
+  issueDelta: IssueDelta;
   partnerIssue: GitHubIssue;
   directoryIssue: GitHubIssue;
   labelRemoved: string[];
   originalLabels: string[];
 }
 
-interface MetaChanges {
+interface IssueDelta {
   title: boolean;
   body: boolean;
   labels: boolean;

--- a/src/twitter/initialize-twitter-map.ts
+++ b/src/twitter/initialize-twitter-map.ts
@@ -1,4 +1,3 @@
-import { readFile } from "fs/promises";
 import { commitTwitterMap } from "../git";
 
 export type TwitterMap = Record<string, string>;
@@ -6,9 +5,13 @@ export type TwitterMap = Record<string, string>;
 export async function initializeTwitterMap() {
   let twitterMap: TwitterMap = {};
   try {
-    twitterMap = JSON.parse(await readFile("./twitter-map.json", "utf8"));
+    const response = await fetch("https://raw.githubusercontent.com/0x4007/devpool-directory/__STORAGE__/twitter-map.json");
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    twitterMap = await response.json();
   } catch (error) {
-    console.log("Couldn't find twitter map artifact, creating a new one");
+    console.log("Couldn't fetch twitter map, creating a new one");
     await commitTwitterMap(twitterMap);
   }
   return twitterMap;

--- a/tests/devpool-issue-handler.test.ts
+++ b/tests/devpool-issue-handler.test.ts
@@ -11,7 +11,7 @@ import { GitHubIssue } from "../src/directory/directory";
 import { getPartnerUrls } from "../src/directory/get-partner-urls";
 import { getRepoUrls } from "../src/directory/get-repo-urls";
 import { newDirectoryIssue } from "../src/directory/new-directory-issue";
-import { syncIssueMetaData } from "../src/directory/sync-issue-meta-data";
+import { updateDirectoryIssue } from "../src/directory/update-issue";
 
 const DEVPOOL_OWNER_NAME = "ubiquity";
 const DEVPOOL_REPO_NAME = "devpool-directory";
@@ -97,7 +97,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -131,7 +131,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -166,7 +166,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -187,7 +187,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: devpoolIssue,
       });
@@ -208,7 +208,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: devpoolIssue,
       });
@@ -232,7 +232,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: devpoolIssue,
       });
@@ -260,7 +260,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: devpoolIssue,
       });
@@ -291,7 +291,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: devpoolIssue,
       });
@@ -312,7 +312,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: devpoolIssue,
       });
@@ -340,7 +340,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: devpoolIssue,
       });
@@ -362,7 +362,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -402,7 +402,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -436,7 +436,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -472,7 +472,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -507,7 +507,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -541,7 +541,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -582,7 +582,7 @@ describe("handleDevPoolIssue", () => {
 
       const issueInDb = createIssues(devpoolIssue, partnerIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: partnerIssue,
         partnerIssue: issueInDb,
       });
@@ -616,7 +616,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, projectIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: projectIssue,
         partnerIssue: devpoolIssue,
       });
@@ -659,7 +659,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, projectIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: projectIssue,
         partnerIssue: devpoolIssue,
       });
@@ -706,7 +706,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, projectIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: projectIssue,
         partnerIssue: devpoolIssue,
       });
@@ -746,7 +746,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, projectIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: projectIssue,
         partnerIssue: devpoolIssue,
       });
@@ -793,7 +793,7 @@ describe("handleDevPoolIssue", () => {
 
       createIssues(devpoolIssue, projectIssue);
 
-      await syncIssueMetaData({
+      await updateDirectoryIssue({
         directoryIssue: projectIssue,
         partnerIssue: devpoolIssue,
       });
@@ -960,7 +960,7 @@ describe("handleDevPoolIssue", () => {
   }
 
   async function validateClosed(projectIssue: GitHubIssue, devpoolIssue: GitHubIssue) {
-    await syncIssueMetaData({
+    await updateDirectoryIssue({
       directoryIssue: projectIssue,
       partnerIssue: devpoolIssue,
     });
@@ -981,7 +981,7 @@ describe("handleDevPoolIssue", () => {
   }
 
   async function validateOpen(projectIssue: GitHubIssue, devpoolIssue: GitHubIssue) {
-    await syncIssueMetaData({
+    await updateDirectoryIssue({
       directoryIssue: projectIssue,
       partnerIssue: devpoolIssue,
     });
@@ -1611,17 +1611,17 @@ describe("calculateStatistics", () => {
     } as GitHubIssue;
 
     createIssues(devpoolIssue, projectIssue1);
-    await syncIssueMetaData({
+    await updateDirectoryIssue({
       directoryIssue: projectIssue1,
       partnerIssue: devpoolIssue,
     });
     createIssues(devpoolIssue2, projectIssue2);
-    await syncIssueMetaData({
+    await updateDirectoryIssue({
       directoryIssue: projectIssue2,
       partnerIssue: devpoolIssue2,
     });
     createIssues(devpoolIssue3, projectIssue3);
-    await syncIssueMetaData({
+    await updateDirectoryIssue({
       directoryIssue: projectIssue3,
       partnerIssue: devpoolIssue3,
     });
@@ -1685,7 +1685,7 @@ describe("calculateStatistics", () => {
     } as GitHubIssue;
 
     createIssues(devpoolIssue, projectIssue1);
-    await syncIssueMetaData({
+    await updateDirectoryIssue({
       directoryIssue: projectIssue1,
       partnerIssue: devpoolIssue,
     });


### PR DESCRIPTION
…ate parameter names for clarity

Resolves https://github.com/ubiquity/devpool-directory-tasks/issues/54

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

QA: https://github.com/0x4007/devpool-directory/actions/runs/11536021329/job/32111752753

260 -> 218 open issues after this run which is aligned with my expectation of how many issues were closed since I pushed the broken code.