### PR TITLE
fix: task spam

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@mswjs/data": "0.16.1",
-    "@octokit/rest": "^21.1.0",
+    "@octokit/rest": "^20.0.2",
     "dotenv": "^16.3.1",
     "jest": "29.7.0",
     "octokit": "^2.0.14",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@mswjs/data": "0.16.1",
-    "@octokit/rest": "^20.0.2",
+    "@octokit/rest": "^21.1.0",
     "dotenv": "^16.3.1",
     "jest": "29.7.0",
     "octokit": "^2.0.14",

--- a/src/directory/new-directory-issue.ts
+++ b/src/directory/new-directory-issue.ts
@@ -18,18 +18,16 @@ export async function newDirectoryIssue(partnerIssue: GitHubIssue, projectUrl: s
     body = partnerIssue.html_url;
   }
 
+  // create a new `id: XXX` label
+  // NOTICE: this is a workaround until https://github.com/octokit/rest.js/issues/479 is solved
   try {
-    const labelNames = getDirectoryIssueLabelsFromPartnerIssue(partnerIssue);
-    // try to create a new label
-    for (let labelName of labelNames) {
-      await octokit.rest.issues.createLabel({
-        owner: DEVPOOL_OWNER_NAME,
-        repo: DEVPOOL_REPO_NAME,
-        name: labelName,
-      });
-    }
+    await octokit.rest.issues.createLabel({
+      owner: DEVPOOL_OWNER_NAME,
+      repo: DEVPOOL_REPO_NAME,
+      name: `id: ${partnerIssue.node_id}`,
+    });
   } catch (err) {
-    console.log('Failed to create a label:', err);
+    console.error("Failed to create a label:", err);
   }
 
   // create a new issue
@@ -42,9 +40,6 @@ export async function newDirectoryIssue(partnerIssue: GitHubIssue, projectUrl: s
       labels: getDirectoryIssueLabelsFromPartnerIssue(partnerIssue),
     });
     console.log(`Created: ${createdIssue.data.html_url} (${partnerIssue.html_url})`);
-    console.log(JSON.stringify(createdIssue.data));
-    console.log(JSON.stringify(partnerIssue));
-    console.log(JSON.stringify(getDirectoryIssueLabelsFromPartnerIssue(partnerIssue)));
 
     if (!createdIssue) {
       console.log("No new issue to tweet about");

--- a/src/directory/new-directory-issue.ts
+++ b/src/directory/new-directory-issue.ts
@@ -28,6 +28,7 @@ export async function newDirectoryIssue(partnerIssue: GitHubIssue, projectUrl: s
       labels: getDirectoryIssueLabelsFromPartnerIssue(partnerIssue),
     });
     console.log(`Created: ${createdIssue.data.html_url} (${partnerIssue.html_url})`);
+    console.log(JSON.stringify(createdIssue.data));
     console.log(JSON.stringify(partnerIssue));
     console.log(JSON.stringify(getDirectoryIssueLabelsFromPartnerIssue(partnerIssue)));
 

--- a/src/directory/new-directory-issue.ts
+++ b/src/directory/new-directory-issue.ts
@@ -28,6 +28,8 @@ export async function newDirectoryIssue(partnerIssue: GitHubIssue, projectUrl: s
       labels: getDirectoryIssueLabelsFromPartnerIssue(partnerIssue),
     });
     console.log(`Created: ${createdIssue.data.html_url} (${partnerIssue.html_url})`);
+    console.log(JSON.stringify(partnerIssue));
+    console.log(JSON.stringify(getDirectoryIssueLabelsFromPartnerIssue(partnerIssue)));
 
     if (!createdIssue) {
       console.log("No new issue to tweet about");

--- a/src/directory/new-directory-issue.ts
+++ b/src/directory/new-directory-issue.ts
@@ -18,6 +18,20 @@ export async function newDirectoryIssue(partnerIssue: GitHubIssue, projectUrl: s
     body = partnerIssue.html_url;
   }
 
+  try {
+    const labelNames = getDirectoryIssueLabelsFromPartnerIssue(partnerIssue);
+    // try to create a new label
+    for (let labelName of labelNames) {
+      await octokit.rest.issues.createLabel({
+        owner: DEVPOOL_OWNER_NAME,
+        repo: DEVPOOL_REPO_NAME,
+        name: labelName,
+      });
+    }
+  } catch (err) {
+    console.log('Failed to create a label:', err);
+  }
+
   // create a new issue
   try {
     const createdIssue = await octokit.rest.issues.create({


### PR DESCRIPTION
Resolves https://github.com/ubiquity/devpool-directory-tasks/issues/57

This PR manually creates a new `id: XXX` label in order to prevent task spamming.

Not sure why `octokit` lib doesn't do it anymore on creating a new github issue. I've provided update [here](https://github.com/octokit/rest.js/issues/479#issuecomment-2611932891).