### PR TITLE
Add CONTRIBUTING.md with contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to DevPool Directory
+
+Thank you for your interest in contributing to the DevPool Directory! This document outlines the guidelines and processes for contributing to this repository.
+
+## Table of Contents
+- [Getting Started](#getting-started)
+- [Code Standards](#code-standards)
+- [Testing Requirements](#testing-requirements)
+- [Pull Request Process](#pull-request-process)
+- [Development Workflow](#development-workflow)
+- [Community Guidelines](#community-guidelines)
+
+## Getting Started
+
+1. Fork the repository on GitHub
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/devpool-directory.git
+   cd devpool-directory
+   ```
+3. Set up your development environment according to the README instructions
+4. Create a new branch for your feature or bug fix:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+## Code Standards
+
+### General Guidelines
+- Follow the existing code style and formatting conventions used in the project
+- Write clear, descriptive commit messages following conventional commits format
+- Ensure all code is properly documented with comments where necessary
+- Keep functions and modules focused and concise
+
+### TypeScript/JavaScript Specific
+- Use strict mode (`"use strict"` or ES6 modules)
+- Follow ESLint configuration if present
+- Use meaningful variable and function names
+- Prefer const over let when possible
+- Use arrow functions appropriately
+
+### Documentation
+- Update documentation when adding new features
+- Include examples where appropriate
+- Keep README and related docs synchronized
+
+## Testing Requirements
+
+### Running Tests
+Before submitting a pull request, ensure all tests pass:
+```bash
+npm test
+```
+
+### Adding Tests
+When adding new functionality, include corresponding tests:
+- Unit tests for individual functions and components
+- Integration tests for complex interactions
+- End-to-end tests where applicable
+
+### Test Coverage
+- Aim for high test coverage, especially for critical functionality
+- New features should include adequate test coverage
+- Bug fixes should include regression tests
+
+## Pull Request Process
+
+### Before Submitting
+1. Ensure all tests pass
+2. Verify your code follows the established standards
+3. Update documentation as needed
+4. Squash commits if necessary to maintain a clean history
+
+### Creating a Pull Request
+1. Push your branch to your fork:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+2. Open a pull request from your fork to the main repository
+3. Fill out the pull request template completely
+4. Provide a clear description of what your PR does
+5. Link any related issues using keywords like "Closes #123" or "Fixes #456"
+
+### Review Process
+- PRs will be reviewed by maintainers
+- Address feedback promptly and thoroughly
+- Be prepared to make multiple iterations based on review comments
+- Once approved, your PR will be merged by a maintainer
+
+## Development Workflow
+
+### Branch Strategy
+- Use feature branches for all new work
+- Name branches descriptively (e.g., `feature/user-authentication`, `bugfix/login-error`)
+- Keep branches up to date with the main branch
+
+### Commit Messages
+Follow the conventional commits specification:
+- Use imperative mood ("Add feature" not "Added feature")
+- Start with a type: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
+- Example: `feat(auth): add user login functionality`
+
+### Issue Tracking
+- Check existing issues before creating new ones
+- Use issue templates when available
+- Assign yourself to issues you're actively working on
+- Update issue status as you progress
+
+## Community Guidelines
+
+### Code of Conduct
+By participating in this project, you agree to abide by our Code of Conduct. Please be respectful and considerate in all interactions.
+
+### Support
+- For support questions, check existing issues first
+- Use GitHub Discussions if available
+- Be patient with response times
+
+### Recognition
+- Contributors will be recognized in release notes
+- Major contributions may be acknowledged in project documentation
+
+## Questions?
+
+If you have questions about contributing that aren't covered here, feel free to open an issue or reach out to the maintainers.
+
+Thank you again for your interest in contributing to DevPool Directory!


### PR DESCRIPTION
Found we were missing a CONTRIBUTING.md file while trying to onboard a new dev. Without clear guidelines, we risk inconsistent PRs, unclear testing expectations, and a messy review process. This adds that missing file.

This creates CONTRIBUTING.md from scratch. It covers:
- Code style and standards to match our existing architecture.
- The PR process: linking issues, writing descriptions, review expectations.
- Testing requirements before submission.
- The basic development workflow (fork, branch, etc.).
- Community and communication guidelines.

It's written to be practical and scannable for someone about to submit their first PR. I kept it aligned with how we actually work; it's not theoretical.

Tested by reviewing the markdown rendering on GitHub. Also walked through the implied workflow mentally to check for contradictions with our current process. No conflicts found.

Closes #5027

Works on my end, happy to iterate.