### PR TITLE
feat: premade configs for partners (#5837)

### DIFF
--- a/config/devpool.config.json
+++ b/config/devpool.config.json
@@ -1,6 +1,6 @@
 {
+  "partners": ["ubiquity"],
   "include": [
-    "ubiquity",
     "ubiquity-os-marketplace",
     "0x4007/uad.ubq.fi",
     "ubiquity-os",
@@ -8,16 +8,7 @@
     "devpool-directory/devpool-directory-tasks",
     "askmiguel"
   ],
-  "exclude": [
-    "ubiquity/series-a",
-    "ubiquity/hackbar",
-    "ubiquity/card-issuance",
-    "ubiquity/research",
-    "ubiquity/recruiting",
-    "ubiquity/ubiquibar",
-    "ubiquity/ubiquibot",
-    "ubiquity/ubiquibot-telegram"
-  ],
+  "exclude": [],
   "explicit_urls": [],
   "data_branch": "__STORAGE__",
   "max_shards": 256

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import dotenv from "dotenv";
 import { ConfigSchema, type AppConfig } from "./schema";
+import { resolvePartners } from "./partners";
 
 dotenv.config();
 
@@ -10,7 +11,22 @@ export function loadConfig(): AppConfig {
   const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, "utf8")) : {};
   const parsed = ConfigSchema.safeParse(raw);
   if (!parsed.success) throw new Error(`Invalid configuration: ${parsed.error.message}`);
-  return parsed.data;
+
+  // Resolve partner presets and merge with explicit include/exclude/urls
+  const partnerResolved = resolvePartners(parsed.data.partners);
+  const config: AppConfig = {
+    partners: parsed.data.partners,
+    // Partner includes come first; explicit include entries are appended
+    include: [...partnerResolved.include, ...parsed.data.include],
+    // Explicit excludes are appended to partner excludes
+    exclude: [...partnerResolved.exclude, ...parsed.data.exclude],
+    // Same for explicit_urls
+    explicit_urls: [...partnerResolved.explicit_urls, ...parsed.data.explicit_urls],
+    data_branch: parsed.data.data_branch,
+    max_shards: parsed.data.max_shards,
+  };
+
+  return config;
 }
 
 export function env(name: string, required = false): string | undefined {

--- a/src/config/partners.ts
+++ b/src/config/partners.ts
@@ -1,0 +1,80 @@
+/**
+ * Predefined partner configurations.
+ * Partners can be referenced by ID instead of configuring include/exclude manually.
+ * Usage: add partner IDs to the `partners` array in devpool.config.json.
+ */
+
+export interface PartnerPreset {
+  /** Org or repo strings to include (same semantics as top-level `include`). */
+  include: string[];
+  /** Org or repo strings to exclude. */
+  exclude: string[];
+  /** Explicit repo URLs to include. */
+  explicit_urls: string[];
+}
+
+/**
+ * Registry of premade partner configurations.
+ * Key is the partner ID used in the `partners` config array.
+ */
+export const PARTNER_PRESETS: Record<string, PartnerPreset> = {
+  ubiquity: {
+    include: ["ubiquity"],
+    exclude: [
+      "ubiquity/series-a",
+      "ubiquity/hackbar",
+      "ubiquity/card-issuance",
+      "ubiquity/research",
+      "ubiquity/recruiting",
+      "ubiquity/ubiquibar",
+      "ubiquity/ubiquibot",
+      "ubiquity/ubiquibot-telegram",
+    ],
+    explicit_urls: [],
+  },
+  "ubiquity-os": {
+    include: ["ubiquity-os"],
+    exclude: [],
+    explicit_urls: [],
+  },
+  "0x4007": {
+    include: ["0x4007"],
+    exclude: [],
+    explicit_urls: [],
+  },
+  ondecentral: {
+    include: ["ondecentral"],
+    exclude: [],
+    explicit_urls: [],
+  },
+  "devpool-directory": {
+    include: ["devpool-directory"],
+    exclude: [],
+    explicit_urls: [],
+  },
+  askmiguel: {
+    include: ["askmiguel"],
+    exclude: [],
+    explicit_urls: [],
+  },
+};
+
+/**
+ * Resolve a list of partner IDs to their merged include/exclude/explicit_urls.
+ * Later partners override earlier ones for overlapping keys.
+ */
+export function resolvePartners(partnerIds: string[]): {
+  include: string[];
+  exclude: string[];
+  explicit_urls: string[];
+} {
+  const merged = { include: [] as string[], exclude: [] as string[], explicit_urls: [] as string[] };
+  for (const id of partnerIds) {
+    const preset = PARTNER_PRESETS[id];
+    if (!preset) continue;
+    merged.include.push(...preset.include);
+    merged.exclude.push(...preset.exclude);
+    merged.explicit_urls.push(...preset.explicit_urls);
+  }
+  return merged;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 
 export const ConfigSchema = z.object({
+  /** Partner preset IDs (keys of PARTNER_PRESETS). Resolved before include/exclude. */
+  partners: z.array(z.string()).default([]),
   include: z.array(z.string()).default([]),
   exclude: z.array(z.string()).default([]),
   explicit_urls: z.array(z.string()).default([]),
   data_branch: z.string().default("__STORAGE__"),
-  max_shards: z.number().int().positive().default(8)
+  max_shards: z.number().int().positive().default(8),
 });
 
 export type AppConfig = z.infer<typeof ConfigSchema>;

--- a/tests/partners.test.ts
+++ b/tests/partners.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "@jest/globals";
+import { PARTNER_PRESETS, resolvePartners } from "../src/config/partners";
+
+describe("Partner presets", () => {
+  test("ubiquity preset has expected shape", () => {
+    const p = PARTNER_PRESETS["ubiquity"];
+    expect(p).toBeDefined();
+    expect(p.include).toContain("ubiquity");
+    expect(p.exclude).toContain("ubiquity/series-a");
+    expect(p.exclude).toContain("ubiquity/hackbar");
+    expect(p.exclude).toContain("ubiquity/ubiquibot");
+    expect(p.exclude).toContain("ubiquity/ubiquibot-telegram");
+    expect(Array.isArray(p.include)).toBe(true);
+    expect(Array.isArray(p.exclude)).toBe(true);
+    expect(Array.isArray(p.explicit_urls)).toBe(true);
+  });
+
+  test("resolvePartners merges multiple partner presets", () => {
+    const resolved = resolvePartners(["ubiquity", "ubiquity-os"]);
+    expect(resolved.include).toContain("ubiquity");
+    expect(resolved.include).toContain("ubiquity-os");
+    expect(resolved.exclude).toContain("ubiquity/series-a");
+    expect(resolved.exclude).toContain("ubiquity/hackbar");
+  });
+
+  test("resolvePartners handles unknown partner IDs gracefully", () => {
+    const resolved = resolvePartners(["ubiquity", "nonexistent-partner"]);
+    expect(resolved.include).toContain("ubiquity");
+    expect(resolved.include).not.toContain("nonexistent-partner");
+  });
+
+  test("resolvePartners returns empty arrays for empty input", () => {
+    const resolved = resolvePartners([]);
+    expect(resolved.include).toEqual([]);
+    expect(resolved.exclude).toEqual([]);
+    expect(resolved.explicit_urls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Add a 'partners' config field that maps to predefined include/exclude configurations. Partners can now be added by referencing a preset ID (e.g. 'ubiquity') instead of configuring include/exclude manually.

### Changes

**src/config/partners.ts** (new):
- PARTNER_PRESETS registry mapping partner IDs to their include/exclude config
- resolvePartners() helper to merge multiple partner presets
- Current presets: ubiquity, ubiquity-os, 0x4007, ondecentral, devpool-directory, askmiguel

**src/config/schema.ts**:
- Added 'partners: z.array(z.string()).default([])' field

**src/config/load.ts**:
- loadConfig() now calls resolvePartners() and merges partner config with explicit include/exclude

**config/devpool.config.json**:
- Migrated 'ubiquity' org to use the new  field instead of manual include/exclude

**tests/partners.test.ts** (new):
- Unit tests for PARTNER_PRESETS and resolvePartners()

### Usage

Partners can now be configured with just their ID:

```json
{
  "partners": ["ubiquity", "ubiquity-os"],
  "include": ["owner/custom-repo"],
  "exclude": [],
  "explicit_urls": []
}
```

Instead of manually specifying all the include/exclude entries.

Closes #5837