### PR TITLE
feat: Differential Reward Distribution for Reopened Issues

### DIFF
--- a/src/directory/calculate-statistics.ts
+++ b/src/directory/calculate-statistics.ts
@@ -1,14 +1,21 @@
 import { GitHubIssue, GitHubLabel } from "./directory";
 
+const REOPENED_MULTIPLIER = 0.5; // Example multiplier for reopened issues
+
 export async function calculateStatistics(issues: GitHubIssue[]): Promise<{ rewards: number; tasks: number }> {
   let rewards = 0;
   let tasks = issues.length;
   for (const issue of issues) {
-    // Parse price from labels or body if present
     const priceLabel = issue.labels.find((label): label is GitHubLabel => typeof label === 'object' && 'name' in label && (label as GitHubLabel).name?.startsWith('Price: '));
     if (priceLabel && priceLabel.name) {
-      const price = parseFloat(priceLabel.name.replace('Price: ', ''));
-      if (!isNaN(price)) rewards += price;
+      let price = parseFloat(priceLabel.name.replace('Price: ', ''));
+      if (!isNaN(price)) {
+        const isReopened = issue.labels.some((label): label is GitHubLabel => typeof label === 'object' && 'name' in label && (label as GitHubLabel).name?.toLowerCase() === 'reopened');
+        if (isReopened) {
+          price *= REOPENED_MULTIPLIER;
+        }
+        rewards += price;
+      }
     }
   }
   return { rewards, tasks };


### PR DESCRIPTION
Resolves #5012. Added logic to apply a differential reward multiplier when calculating bounties for issues that have been reopened, ensuring fair compensation for extended or repeated work.