### PR TITLE
[codex] Handle stale proposals

### DIFF
--- a/.github/workflows/old-proposals.yml
+++ b/.github/workflows/old-proposals.yml
@@ -1,0 +1,54 @@
+name: Handle Old Proposals
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report actions without writing to GitHub"
+        type: boolean
+        default: true
+      stale_after_days:
+        description: "Days without updates before asking for a proposal update"
+        type: number
+        default: 30
+      response_window_days:
+        description: "Days to wait after the update request before closing"
+        type: number
+        default: 7
+      admin_mention:
+        description: "Optional GitHub mention to include in update requests"
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  handle-old-proposals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install deps
+        run: bun install
+      - name: Create GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Handle old proposals
+        run: bun src/cli/old-proposals.ts
+        env:
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          DIRECTORY_OWNER: ${{ github.repository_owner }}
+          DIRECTORY_REPO: ${{ github.event.repository.name }}
+          OLD_PROPOSAL_DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          OLD_PROPOSAL_STALE_AFTER_DAYS: ${{ inputs.stale_after_days || '30' }}
+          OLD_PROPOSAL_RESPONSE_WINDOW_DAYS: ${{ inputs.response_window_days || '7' }}
+          OLD_PROPOSAL_ADMIN_MENTION: ${{ inputs.admin_mention }}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "test": "node --test --import tsx tests/old-proposals.test.ts",
+    "old-proposals": "tsx src/cli/old-proposals.ts",
     "plan": "npm run build && node dist/cli/plan.js",
     "sync:shard": "npm run build && node dist/cli/sync-shard.js",
     "aggregate": "npm run build && node dist/cli/aggregate.js",

--- a/src/cli/old-proposals.ts
+++ b/src/cli/old-proposals.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env -S node --enable-source-maps
+import process from "node:process";
+import type { PartnerIssue } from "../artifacts/types";
+import { readJsonFromStorage } from "../artifacts/storage";
+import { getOctokitRead } from "../github/client";
+import { buildOldProposalConfig, handleOldProposals } from "../proposals/old-proposals";
+
+async function main() {
+  const config = buildOldProposalConfig();
+  const proposals = (await readJsonFromStorage<PartnerIssue[]>("partner-open-proposals.json")) ?? [];
+  // Proposal updates are written to partner repositories, not directory mirrors.
+  // getOctokitRead prefers GH_TOKEN when present, which is the cross-repo token
+  // already used by sync jobs for broad partner access.
+  const octokit = getOctokitRead();
+  const actions = await handleOldProposals({ octokit, proposals, config });
+
+  console.log(
+    JSON.stringify(
+      {
+        dryRun: config.dryRun,
+        scanned: proposals.length,
+        requestedUpdates: actions.filter((action) => action.type === "request-update").length,
+        closed: actions.filter((action) => action.type === "close").length,
+        skipped: actions.filter((action) => action.type === "skip").length,
+        actions,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/proposals/old-proposals.ts
+++ b/src/proposals/old-proposals.ts
@@ -1,0 +1,193 @@
+import type { PartnerIssue } from "../artifacts/types";
+
+export const UPDATE_REQUEST_MARKER = "<!-- devpool-old-proposal:update-request -->";
+export const CLOSE_MARKER = "<!-- devpool-old-proposal:closed -->";
+
+export type OldProposalConfig = {
+  staleAfterDays: number;
+  responseWindowDays: number;
+  adminMention?: string;
+  dryRun: boolean;
+};
+
+export const DEFAULT_OLD_PROPOSAL_CONFIG: OldProposalConfig = {
+  staleAfterDays: 30,
+  responseWindowDays: 7,
+  dryRun: true,
+};
+
+type ProposalComment = {
+  id?: number;
+  body?: string | null;
+  created_at: string;
+  user?: {
+    login?: string;
+    type?: string;
+  } | null;
+  reactions?: {
+    total_count?: number;
+  } | null;
+};
+
+type OctokitLike = {
+  paginate?: (fn: unknown, params: Record<string, unknown>) => Promise<ProposalComment[]>;
+  rest: {
+    issues: {
+      listComments: (...args: any[]) => Promise<{ data: ProposalComment[] }>;
+      createComment: (...args: any[]) => Promise<unknown>;
+      update: (...args: any[]) => Promise<unknown>;
+    };
+  };
+};
+
+type SkipReason = "priced" | "not-open" | "not-stale" | "waiting" | "responded";
+
+export type OldProposalAction =
+  | { type: "request-update"; issue: string; reason: "stale"; dryRun: boolean }
+  | { type: "close"; issue: string; reason: "expired"; dryRun: boolean }
+  | { type: "skip"; issue: string; reason: SkipReason };
+
+export function buildOldProposalConfig(env: NodeJS.ProcessEnv = process.env): OldProposalConfig {
+  return {
+    staleAfterDays: parsePositiveInt(env.OLD_PROPOSAL_STALE_AFTER_DAYS, DEFAULT_OLD_PROPOSAL_CONFIG.staleAfterDays),
+    responseWindowDays: parsePositiveInt(env.OLD_PROPOSAL_RESPONSE_WINDOW_DAYS, DEFAULT_OLD_PROPOSAL_CONFIG.responseWindowDays),
+    adminMention: env.OLD_PROPOSAL_ADMIN_MENTION || undefined,
+    dryRun: env.OLD_PROPOSAL_DRY_RUN !== "false",
+  };
+}
+
+export async function handleOldProposals(input: {
+  octokit: OctokitLike;
+  proposals: PartnerIssue[];
+  config?: OldProposalConfig;
+  now?: Date;
+}): Promise<OldProposalAction[]> {
+  const config = input.config ?? DEFAULT_OLD_PROPOSAL_CONFIG;
+  const now = input.now ?? new Date();
+  const actions: OldProposalAction[] = [];
+
+  for (const proposal of input.proposals) {
+    const issueRef = `${proposal.owner}/${proposal.repo}#${proposal.number}`;
+    const precheck = precheckProposal(proposal, now, config);
+    if (precheck) {
+      actions.push({ type: "skip", issue: issueRef, reason: precheck });
+      continue;
+    }
+
+    const comments = await listComments(input.octokit, proposal);
+    const requestComment = findLatestUpdateRequest(comments);
+
+    if (!requestComment) {
+      actions.push({ type: "request-update", issue: issueRef, reason: "stale", dryRun: config.dryRun });
+      if (!config.dryRun) {
+        await input.octokit.rest.issues.createComment({
+          owner: proposal.owner,
+          repo: proposal.repo,
+          issue_number: proposal.number,
+          body: buildUpdateRequestBody(config),
+        });
+      }
+      continue;
+    }
+
+    if (hasResponseAfterRequest(comments, requestComment)) {
+      actions.push({ type: "skip", issue: issueRef, reason: "responded" });
+      continue;
+    }
+
+    if (ageInDays(requestComment.created_at, now) < config.responseWindowDays) {
+      actions.push({ type: "skip", issue: issueRef, reason: "waiting" });
+      continue;
+    }
+
+    actions.push({ type: "close", issue: issueRef, reason: "expired", dryRun: config.dryRun });
+    if (!config.dryRun) {
+      await input.octokit.rest.issues.createComment({
+        owner: proposal.owner,
+        repo: proposal.repo,
+        issue_number: proposal.number,
+        body: buildCloseCommentBody(),
+      });
+      await input.octokit.rest.issues.update({
+        owner: proposal.owner,
+        repo: proposal.repo,
+        issue_number: proposal.number,
+        state: "closed",
+        state_reason: "not_planned",
+      });
+    }
+  }
+
+  return actions;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function precheckProposal(
+  proposal: PartnerIssue,
+  now: Date,
+  config: OldProposalConfig
+): SkipReason | null {
+  if (proposal.state !== "open") return "not-open";
+  if (proposal.labels.some((label) => /^Price:\s*/.test(label))) return "priced";
+  if (ageInDays(proposal.updated_at, now) < config.staleAfterDays) return "not-stale";
+  return null;
+}
+
+async function listComments(octokit: OctokitLike, proposal: PartnerIssue): Promise<ProposalComment[]> {
+  const params = {
+    owner: proposal.owner,
+    repo: proposal.repo,
+    issue_number: proposal.number,
+    per_page: 100,
+  };
+
+  if (octokit.paginate) {
+    return octokit.paginate(octokit.rest.issues.listComments, params);
+  }
+
+  const { data } = await octokit.rest.issues.listComments(params);
+  return data;
+}
+
+function findLatestUpdateRequest(comments: ProposalComment[]): ProposalComment | null {
+  return comments
+    .filter((comment) => comment.body?.includes(UPDATE_REQUEST_MARKER))
+    .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0] ?? null;
+}
+
+function hasResponseAfterRequest(comments: ProposalComment[], requestComment: ProposalComment): boolean {
+  if ((requestComment.reactions?.total_count ?? 0) > 0) return true;
+
+  const requestTime = Date.parse(requestComment.created_at);
+  return comments.some((comment) => {
+    if (comment.body?.includes(UPDATE_REQUEST_MARKER)) return false;
+    if (Date.parse(comment.created_at) <= requestTime) return false;
+    return comment.user?.type !== "Bot";
+  });
+}
+
+function ageInDays(isoDate: string, now: Date): number {
+  return (now.getTime() - Date.parse(isoDate)) / 86_400_000;
+}
+
+function buildUpdateRequestBody(config: OldProposalConfig): string {
+  const admin = config.adminMention ? `${config.adminMention} ` : "";
+  return [
+    UPDATE_REQUEST_MARKER,
+    `${admin}Could you please share an update on whether this proposal is still relevant?`,
+    "",
+    `If there is no response within ${config.responseWindowDays} days, this may be closed as not planned.`,
+  ].join("\n");
+}
+
+function buildCloseCommentBody(): string {
+  return [
+    CLOSE_MARKER,
+    "Closing this stale proposal as not planned because there was no response after the update request window.",
+  ].join("\n");
+}

--- a/tests/old-proposals.test.ts
+++ b/tests/old-proposals.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  DEFAULT_OLD_PROPOSAL_CONFIG,
+  UPDATE_REQUEST_MARKER,
+  handleOldProposals,
+  type OldProposalConfig,
+} from "../src/proposals/old-proposals";
+
+const now = new Date("2026-05-25T00:00:00.000Z");
+
+function issue(overrides: Record<string, unknown> = {}) {
+  return {
+    owner: "ubiquity-os",
+    repo: "plugins-wishlist",
+    number: 70,
+    node_id: "node-70",
+    title: "Handling old proposals",
+    url: "https://github.com/ubiquity-os/plugins-wishlist/issues/70",
+    labels: [],
+    assignees: [],
+    state: "open" as const,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function comment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    body: "",
+    created_at: "2026-05-01T00:00:00.000Z",
+    user: { login: "devpool-directory-superintendent", type: "Bot" },
+    reactions: { total_count: 0 },
+    ...overrides,
+  };
+}
+
+function makeOctokit(comments: unknown[] = []) {
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const octokit = {
+    rest: {
+      issues: {
+        listComments: async () => ({ data: comments }),
+        createComment: async (params: Record<string, unknown>) => {
+          calls.push({ method: "createComment", params });
+          return { data: { id: calls.length } };
+        },
+        update: async (params: Record<string, unknown>) => {
+          calls.push({ method: "update", params });
+          return { data: { number: params.issue_number } };
+        },
+      },
+    },
+    paginate: async (fn: () => Promise<{ data: unknown[] }>) => (await fn()).data,
+  };
+
+  return { octokit, calls };
+}
+
+const config: OldProposalConfig = {
+  ...DEFAULT_OLD_PROPOSAL_CONFIG,
+  staleAfterDays: 30,
+  responseWindowDays: 7,
+  dryRun: false,
+};
+
+describe("handleOldProposals", () => {
+  test("asks for an update when an unpriced proposal is stale and has not been reminded", async () => {
+    const { octokit, calls } = makeOctokit();
+
+    const actions = await handleOldProposals({
+      octokit,
+      proposals: [issue()],
+      config,
+      now,
+    });
+
+    assert.equal(actions[0].type, "request-update");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "createComment");
+    assert.match(String(calls[0].params.body), new RegExp(UPDATE_REQUEST_MARKER));
+  });
+
+  test("closes an old proposal when the update request expired without a response", async () => {
+    const { octokit, calls } = makeOctokit([
+      comment({
+        body: `${UPDATE_REQUEST_MARKER}\nPlease share an update.`,
+        created_at: "2026-05-01T00:00:00.000Z",
+      }),
+    ]);
+
+    const actions = await handleOldProposals({
+      octokit,
+      proposals: [issue()],
+      config,
+      now,
+    });
+
+    assert.equal(actions[0].type, "close");
+    assert.deepEqual(
+      calls.map((call) => call.method),
+      ["createComment", "update"]
+    );
+    assert.equal(calls[1].params.state, "closed");
+    assert.equal(calls[1].params.state_reason, "not_planned");
+  });
+
+  test("does not close when a human responded after the update request", async () => {
+    const { octokit, calls } = makeOctokit([
+      comment({
+        body: `${UPDATE_REQUEST_MARKER}\nPlease share an update.`,
+        created_at: "2026-05-01T00:00:00.000Z",
+      }),
+      comment({
+        id: 2,
+        body: "Still relevant.",
+        created_at: "2026-05-10T00:00:00.000Z",
+        user: { login: "0x4007", type: "User" },
+      }),
+    ]);
+
+    const actions = await handleOldProposals({
+      octokit,
+      proposals: [issue()],
+      config,
+      now,
+    });
+
+    assert.equal(actions[0].type, "skip");
+    assert.equal(actions[0].reason, "responded");
+    assert.equal(calls.length, 0);
+  });
+
+  test("dry run reports the update request without writing to GitHub", async () => {
+    const { octokit, calls } = makeOctokit();
+
+    const actions = await handleOldProposals({
+      octokit,
+      proposals: [issue()],
+      config: { ...config, dryRun: true },
+      now,
+    });
+
+    assert.equal(actions[0].type, "request-update");
+    assert.equal(actions[0].dryRun, true);
+    assert.equal(calls.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a typed old-proposal handler that requests updates for stale unpriced proposals and closes them as not planned after the response window expires.
- Adds a dry-run capable CLI backed by `partner-open-proposals.json` and a scheduled/manual workflow.
- Adds focused Node test coverage for request, close, response-skip, and dry-run paths.

## Test Plan
- `npm test`
- `npm run build`
- `git diff --check`
- `DIRECTORY_OWNER=devpool-directory DIRECTORY_REPO=devpool-directory-does-not-exist OLD_PROPOSAL_DRY_RUN=true npm run old-proposals`

Closes devpool-directory/devpool-directory#5058
Refs ubiquity-os/plugins-wishlist#70