### PR TITLE
fix: correct reward calculation precision and implement body-based price parsing

### DIFF
--- a/src/artifacts/merge.ts
+++ b/src/artifacts/merge.ts
@@ -27,7 +27,7 @@ export function computeStatistics(issues: PartnerIssue[], mirror: MirrorState): 
   for (const issue of issues) {
     const m = mirror[issue.node_id];
     const priceLabel = m?.price_label ?? null;
-    const price = priceLabel ? parseInt(priceLabel.replace(/[^0-9]/g, ""), 10) : NaN;
+    const price = priceLabel ? parseFloat(priceLabel.replace(/[^0-9.]/g, "")) : NaN;
     const amount = Number.isFinite(price) ? price : 0;
 
     if (issue.state === "open") {

--- a/src/directory/calculate-statistics.ts
+++ b/src/directory/calculate-statistics.ts
@@ -4,12 +4,23 @@ export async function calculateStatistics(issues: GitHubIssue[]): Promise<{ rewa
   let rewards = 0;
   let tasks = issues.length;
   for (const issue of issues) {
-    // Parse price from labels or body if present
+    let price = NaN;
+
+    // 1. Check labels
     const priceLabel = issue.labels.find((label): label is GitHubLabel => typeof label === 'object' && 'name' in label && (label as GitHubLabel).name?.startsWith('Price: '));
     if (priceLabel && priceLabel.name) {
-      const price = parseFloat(priceLabel.name.replace('Price: ', ''));
-      if (!isNaN(price)) rewards += price;
+      price = parseFloat(priceLabel.name.replace('Price: ', ''));
     }
+
+    // 2. Check body if label price is missing
+    if (isNaN(price) && issue.body) {
+      const bodyMatch = issue.body.match(/(?:Price:\s*|\$)\s*(\d+(?:\.\d+)?)/i);
+      if (bodyMatch) {
+        price = parseFloat(bodyMatch[1]);
+      }
+    }
+
+    if (!isNaN(price)) rewards += price;
   }
   return { rewards, tasks };
 }


### PR DESCRIPTION
This PR fixes a critical bug in reward calculation where decimal values were ignored or incorrectly parsed, and implements the missing functionality to parse prices from issue bodies.

**Changes:**
1. **Fixed Decimal Precision**: Updated  to use  and a decimal-preserving regex instead of  with non-digit removal. This prevents rewards like /usr/bin/bash.50 from being incorrectly read as 50 or .50 as 1.
2. **Implemented Body Parsing**: Updated  to search for price patterns (e.g., 'Price: 10' or '0') in the issue body when no price label is present.

This directly addresses the goal of validating and correcting reward generation behavior.

Closes #5887