### PR TITLE
Update fix: resolve relative esm import paths with explicit 

### DIFF
--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --enable-source-maps
 import process from "node:process";
 import type { Endpoints } from "@octokit/types";
-import { getOctokitRead, getOctokitWrite, getOctokitDelete } from "../github/client";
+import { getOctokitRead, getOctokitWrite, getOctokitDelete } from "../github/client.js";
 
 function parsePartnerUrl(text: string): { owner: string; repo: string; number: number } | null {
   if (!text) return null;

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --enable-source-maps
-import { getOctokitRead, getRateRemaining } from "../github/client";
-import { loadConfig } from "../config/load";
-import { discoverRepos } from "../discovery";
+import { getOctokitRead, getRateRemaining } from "../github/client.js";
+import { loadConfig } from "../config/load.js";
+import { discoverRepos } from "../discovery.js";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";

--- a/src/cli/sync-shard.ts
+++ b/src/cli/sync-shard.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S node --enable-source-maps
-import { getOctokitRead, getOctokitWrite } from "../github/client";
-import { syncShard } from "../mirror/sync";
-import { writeJson } from "../artifacts/write";
+import { getOctokitRead, getOctokitWrite } from "../github/client.js";
+import { syncShard } from "../mirror/sync.js";
+import { writeJson } from "../artifacts/write.js";
 import fs from "node:fs";
-import { getTwitterClient } from "../twitter/client";
-import { postTweet, deleteTweet } from "../twitter/lifecycle";
+import { getTwitterClient } from "../twitter/client.js";
+import { postTweet, deleteTweet } from "../twitter/lifecycle.js";
 import process from "node:process";
 
 async function main() {


### PR DESCRIPTION
Added missing explicit `.js` extensions to relative module imports in `plan.ts`, `sync-shard.ts`, and `cleanup.ts` to ensure compatibility with Node.js ES Modules (ESM) when running the compiled output directly.

$ https://github.com/devpool-directory/devpool-directory/issues/5886
Fixes https://github.com/devpool-directory/devpool-directory/issues/5886