### PR TITLE
Fix fix: retrieve partner avatar using request instead of pa

### DIFF
--- a/src/cli/cleanup.ts
+++ b/src/cli/cleanup.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --enable-source-maps
 import process from "node:process";
 import type { Endpoints } from "@octokit/types";
-import { getOctokitRead, getOctokitWrite, getOctokitDelete } from "../github/client";
+import { getOctokitRead, getOctokitWrite, getOctokitDelete } from "../github/client.js";
 
 function parsePartnerUrl(text: string): { owner: string; repo: string; number: number } | null {
   if (!text) return null;

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --enable-source-maps
-import { getOctokitRead, getRateRemaining } from "../github/client";
-import { loadConfig } from "../config/load";
-import { discoverRepos } from "../discovery";
+import { getOctokitRead, getRateRemaining } from "../github/client.js";
+import { loadConfig } from "../config/load.js";
+import { discoverRepos } from "../discovery.js";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";

--- a/src/cli/sync-shard.ts
+++ b/src/cli/sync-shard.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S node --enable-source-maps
-import { getOctokitRead, getOctokitWrite } from "../github/client";
-import { syncShard } from "../mirror/sync";
-import { writeJson } from "../artifacts/write";
+import { getOctokitRead, getOctokitWrite } from "../github/client.js";
+import { syncShard } from "../mirror/sync.js";
+import { writeJson } from "../artifacts/write.js";
 import fs from "node:fs";
-import { getTwitterClient } from "../twitter/client";
-import { postTweet, deleteTweet } from "../twitter/lifecycle";
+import { getTwitterClient } from "../twitter/client.js";
+import { postTweet, deleteTweet } from "../twitter/lifecycle.js";
 import process from "node:process";
 
 async function main() {

--- a/src/directory/get-partner-avatars.ts
+++ b/src/directory/get-partner-avatars.ts
@@ -1,18 +1,15 @@
-import { GitHubOrganization, octokit } from "./directory";
+import { octokit } from "./directory";
 
 const avatarMemo = new Map<string, { ownerName: string; avatar_url?: string }>();
 
 export async function getPartnerAvatars(ownerName: string): Promise<{ ownerName: string; avatar_url?: string }> {
   if (avatarMemo.has(ownerName)) return avatarMemo.get(ownerName)!;
   try {
-    const orgResp: GitHubOrganization[] = await octokit.paginate({
-      method: "GET",
-      url: `/users/${ownerName}`,
+    const { data: user } = await octokit.request("GET /users/{username}", {
+      username: ownerName,
     });
 
-    const org = orgResp.find((org) => org.login === ownerName);
-
-    const result = { ownerName, avatar_url: org ? org.avatar_url : undefined };
+    const result = { ownerName, avatar_url: user?.avatar_url || undefined };
     avatarMemo.set(ownerName, result);
     return result;
   } catch (error) {


### PR DESCRIPTION
The getPartnerAvatars function was incorrectly attempting to use `octokit.paginate` on the `/users/{username}` endpoint, which returns a single user/organization object rather than a list. This was changed to a direct `octokit.request('GET /users/{username}')` call to correctly fetch the profile data and extract the avatar URL.

$ https://github.com/devpool-directory/devpool-directory/issues/5000
Fixes https://github.com/devpool-directory/devpool-directory/issues/5000